### PR TITLE
MessageFormat link points to pluralization docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
             <div class="span4">
               <h2>Features</h2>
 
-              <p>It provides components like filters and directives, asynchronous loading of i18n data, full pluralization support through <a href="#">MessageFormat</a> and much more!</p>
+              <p>It provides components like filters and directives, asynchronous loading of i18n data, full pluralization support through <a href="docs/#/guide/14_pluralization">MessageFormat</a> and much more!</p>
             </div>
 
             <div class="span4">


### PR DESCRIPTION
Made the MessageFormat link point to the pluralization documentation. From that page there are further links to the actual MessageFormat js library itself.
